### PR TITLE
Redirect back to href, preserve project_id query

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ const projectIdFromBrowser = locationMatch(/\W?project_id=(\w+)/);
 const baseConfig = {
   development: {
     caesar: 'https://caesar-staging.zooniverse.org',
-    origin: window.location.origin,
+    origin: window.location.href,
     projectId: projectIdFromBrowser || '1613',
     panoptesAppId:
       '16ac801e4ad438d929d30668206df31294e7a7222ce3f449a1c4b45cd80d44cc',
@@ -32,7 +32,7 @@ const baseConfig = {
   },
   production: {
     caesar: 'https://caesar.zooniverse.org',
-    origin: window.location.origin,
+    origin: window.location.href,
     panoptesAppId:
       '940c60fa02251f156c0d9129e3b8d885424fe729da4e4a7750525ca154bdb3d7',
     projectId: projectIdFromBrowser || '1558',


### PR DESCRIPTION
The Field Book supports any project properly configured in Caesar with a `project_id=1234` query param, i.e. https://field-book.notesfromnature.org/?project_id=9480. However, after sign-in the query param is dropped because the redirect is just the origin. 

This PR edits the return redirect from the location.origin to the location.href, preserving the query param.

This change will allow each (properly Caesar configured) NfN project to have it's own Field Book.