### PR TITLE
Fix build linting error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,7 @@
     ],
     "no-console": 1,
     "prettier/prettier": [
-      "error",
+      "warn",
       {
         "singleQuote": true,
         "trailingComma": "none"

--- a/src/containers/BadgeContainer.jsx
+++ b/src/containers/BadgeContainer.jsx
@@ -55,9 +55,6 @@ class BadgeContainer extends React.Component {
           }
         })
         .catch(() => console.warn('Failed to fetch Caesar data.'));
-
-      // this.setState({ caesarData: mockData });
-
     }
   }
 


### PR DESCRIPTION
After #124 a linting error introduced with #123 caused a build error. This PR addresses the specific linting issue and changes the prettier linting issues from "error" to "warn".